### PR TITLE
feat: added banner and update subscription check to make maintained actions free for public repos

### DIFF
--- a/.github/workflows/actions_release.yml
+++ b/.github/workflows/actions_release.yml
@@ -6,6 +6,10 @@ on:
       tag:
         description: "Tag for the release"
         required: true
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
 
 permissions:
   contents: read
@@ -19,3 +23,4 @@ jobs:
     uses: step-security/reusable-workflows/.github/workflows/actions_release.yaml@v1
     with:
       tag: "${{ github.event.inputs.tag }}"
+      node_version: "${{ github.event.inputs.node_version }}"

--- a/.github/workflows/audit_package.yml
+++ b/.github/workflows/audit_package.yml
@@ -15,7 +15,11 @@ on:
         description: "Specify the build script to run"
         required: false
         type: string
-        default: "yarn build"        
+        default: "yarn build"
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
 
   schedule:
     - cron: "0 0 * * 1"
@@ -27,6 +31,7 @@ jobs:
       base_branch: ${{ github.event.inputs.base_branch || 'main' }}
       package_manager: "yarn"
       script: ${{ github.event.inputs.script || 'yarn build' }}
+      node_version: "${{ inputs.node_version || '24' }}"
 
 permissions:
   contents: write

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![StepSecurity Maintained Action](https://raw.githubusercontent.com/step-security/maintained-actions-assets/main/assets/maintained-action-banner.png)](https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions)
+
 *This action can only be run on Linux runners as it requires Docker to be available in the environment*
 
 # Nats Action

--- a/action.yml
+++ b/action.yml
@@ -13,5 +13,5 @@ inputs:
     required: false
     default: "4222"
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"

--- a/dist/index.js
+++ b/dist/index.js
@@ -37,22 +37,43 @@ const randomstring_1 = __nccwpck_require__(5581);
 const exec_1 = __nccwpck_require__(1514);
 const createNetwork_1 = __nccwpck_require__(7590);
 const core = tslib_1.__importStar(__nccwpck_require__(2186));
+const fs = tslib_1.__importStar(__nccwpck_require__(7147));
 const axios_1 = tslib_1.__importStar(__nccwpck_require__(8757));
 function validateSubscription() {
-    var _a;
+    var _a, _b;
     return tslib_1.__awaiter(this, void 0, void 0, function* () {
-        const API_URL = `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/subscription`;
+        const eventPath = process.env.GITHUB_EVENT_PATH;
+        let repoPrivate;
+        if (eventPath && fs.existsSync(eventPath)) {
+            const eventData = JSON.parse(fs.readFileSync(eventPath, 'utf8'));
+            repoPrivate = (_a = eventData === null || eventData === void 0 ? void 0 : eventData.repository) === null || _a === void 0 ? void 0 : _a.private;
+        }
+        const upstream = 'onichandame/nats-action';
+        const action = process.env.GITHUB_ACTION_REPOSITORY;
+        const docsUrl = 'https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions';
+        core.info('');
+        core.info('\u001b[1;36mStepSecurity Maintained Action\u001b[0m');
+        core.info(`Secure drop-in replacement for ${upstream}`);
+        if (repoPrivate === false)
+            core.info('\u001b[32m\u2713 Free for public repositories\u001b[0m');
+        core.info(`\u001b[36mLearn more:\u001b[0m ${docsUrl}`);
+        core.info('');
+        if (repoPrivate === false)
+            return;
+        const serverUrl = process.env.GITHUB_SERVER_URL || 'https://github.com';
+        const body = { action: action || '' };
+        if (serverUrl !== 'https://github.com')
+            body.ghes_server = serverUrl;
         try {
-            yield axios_1.default.get(API_URL, { timeout: 3000 });
+            yield axios_1.default.post(`https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/maintained-actions-subscription`, body, { timeout: 3000 });
         }
         catch (error) {
-            if ((0, axios_1.isAxiosError)(error) && ((_a = error.response) === null || _a === void 0 ? void 0 : _a.status) === 403) {
-                core.error("Subscription is not valid. Reach out to support@stepsecurity.io");
+            if ((0, axios_1.isAxiosError)(error) && ((_b = error.response) === null || _b === void 0 ? void 0 : _b.status) === 403) {
+                core.error(`\u001b[1;31mThis action requires a StepSecurity subscription for private repositories.\u001b[0m`);
+                core.error(`\u001b[31mLearn how to enable a subscription: ${docsUrl}\u001b[0m`);
                 process.exit(1);
             }
-            else {
-                core.info("Timeout or API not reachable. Continuing to next step.");
-            }
+            core.info('Timeout or API not reachable. Continuing to next step.');
         }
     });
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "src"
   ],
   "engines": {
-    "node": ">=10"
+    "node": ">=24"
   },
   "scripts": {
     "build": "tsc && ncc build",

--- a/src/startServer.ts
+++ b/src/startServer.ts
@@ -3,22 +3,53 @@ import { exec } from "@actions/exec"
 
 import { createNetwork } from "./createNetwork"
 import * as core from "@actions/core"
+import * as fs from "fs"
 import axios, { isAxiosError } from "axios"
 
 async function validateSubscription(): Promise<void> {
-  const API_URL = `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/subscription`
+  const eventPath = process.env.GITHUB_EVENT_PATH
+  let repoPrivate: boolean | undefined
 
+  if (eventPath && fs.existsSync(eventPath)) {
+    const eventData = JSON.parse(fs.readFileSync(eventPath, 'utf8'))
+    repoPrivate = eventData?.repository?.private
+  }
+
+  const upstream = 'onichandame/nats-action'
+  const action = process.env.GITHUB_ACTION_REPOSITORY
+  const docsUrl =
+    'https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions'
+
+  core.info('')
+  core.info('\u001b[1;36mStepSecurity Maintained Action\u001b[0m')
+  core.info(`Secure drop-in replacement for ${upstream}`)
+  if (repoPrivate === false)
+    core.info('\u001b[32m\u2713 Free for public repositories\u001b[0m')
+  core.info(`\u001b[36mLearn more:\u001b[0m ${docsUrl}`)
+  core.info('')
+
+  if (repoPrivate === false) return
+
+  const serverUrl = process.env.GITHUB_SERVER_URL || 'https://github.com'
+  const body: Record<string, string> = {action: action || ''}
+  if (serverUrl !== 'https://github.com') body.ghes_server = serverUrl
   try {
-    await axios.get(API_URL, { timeout: 3000 })
+    await axios.post(
+      `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/maintained-actions-subscription`,
+      body,
+      {timeout: 3000}
+    )
   } catch (error) {
     if (isAxiosError(error) && error.response?.status === 403) {
       core.error(
-        "Subscription is not valid. Reach out to support@stepsecurity.io",
+        `\u001b[1;31mThis action requires a StepSecurity subscription for private repositories.\u001b[0m`
+      )
+      core.error(
+        `\u001b[31mLearn how to enable a subscription: ${docsUrl}\u001b[0m`
       )
       process.exit(1)
-    } else {
-      core.info("Timeout or API not reachable. Continuing to next step.")
     }
+    core.info('Timeout or API not reachable. Continuing to next step.')
   }
 }
 


### PR DESCRIPTION
## Summary

- Added StepSecurity Maintained Action banner to README.md
- Updated subscription validation: public repositories are now free (no API check)
- Upgraded Node.js runtime to node24 (if applicable)
- Updated workflow files with configurable node_version input (if applicable)

## Changes by type
- **TypeScript/JS actions**: replaced `validateSubscription()` body, updated action.yml to node24, updated 3 workflow files, rebuilt dist/
- **Docker actions**: replaced entrypoint.sh subscription block, ensured jq is installed in Dockerfile
- **Composite actions**: added Subscription check step to action.yml

## Verification
- [ ] Subscription check skips for public repos
- [ ] Subscription check fires for private repos
- [ ] README banner is present at the top
- [ ] Build passes (TS/JS actions)

Auto-generated by StepSecurity update-propagator. Task ID: 20260414T051935Z